### PR TITLE
Add Playwright browser test, bump tessellation to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "tessellation"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a146ca4affc1c78b2cfb780624c40778131b07e6f01217cdd5c3005eb4de9"
+checksum = "f8a75dabdab207bf25bf1268897541c7223be417e4bb2ea23d7c9341ab5d50af"
 dependencies = [
  "bbox",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ js-sys = "0.3"
 nalgebra = "0.34"
 piccolo = "0.3"
 stl_io = "0.11"
-tessellation = "0.9"
+tessellation = "0.11"
 wasm-bindgen = "0.2"
 
 # getrandom needs explicit WASM features for both the 0.2.x and 0.3.x lines

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@codemirror/theme-one-dark": "^6.0.0",
         "codemirror": "^6.0.0",
         "esbuild": "^0.24.0",
+        "playwright": "^1.58.2",
         "three": "^0.170.0"
       }
     },
@@ -605,6 +606,50 @@
         "@esbuild/win32-arm64": "0.24.2",
         "@esbuild/win32-ia32": "0.24.2",
         "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/style-mod": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "node build.mjs",
     "build:release": "node build.mjs --release",
-    "serve": "node serve.mjs"
+    "serve": "node serve.mjs",
+    "test:browser": "node tests/browser.mjs",
+    "test:browser:screenshot": "node tests/browser.mjs --screenshot"
   },
   "devDependencies": {
     "@codemirror/language": "^6.0.0",
@@ -13,6 +15,7 @@
     "@codemirror/theme-one-dark": "^6.0.0",
     "codemirror": "^6.0.0",
     "esbuild": "^0.24.0",
+    "playwright": "^1.58.2",
     "three": "^0.170.0"
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,6 @@ struct ObjectAdaptor {
 }
 
 impl ImplicitFunction<Float> for ObjectAdaptor {
-    fn bbox(&self) -> &implicit3d::BoundingBox<Float> {
-        self.object.bbox()
-    }
     fn value(&self, p: &nalgebra::Point3<Float>) -> Float {
         self.object.approx_value(p, TESSELLATION_RESOLUTION)
     }

--- a/tests/browser.mjs
+++ b/tests/browser.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Playwright smoke test.
+ * Starts the esbuild dev server, opens the app in headless Chromium,
+ * clicks Run, and checks for errors.
+ *
+ * Usage:  node tests/browser.mjs [--screenshot]
+ * Prereqs: wasm-pack build --target web  (dist/truescad_bg.wasm must exist)
+ */
+
+import * as esbuild from "esbuild";
+import { chromium } from "playwright";
+import { cpSync, mkdirSync, existsSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const SCREENSHOT = process.argv.includes("--screenshot");
+const PORT = 8081; // use a different port from the dev server
+
+// ── 1. Verify WASM build exists ───────────────────────────────────────────────
+
+const wasmFile = resolve(ROOT, "pkg/truescad_bg.wasm");
+if (!existsSync(wasmFile)) {
+  console.error("ERROR: pkg/truescad_bg.wasm not found.");
+  console.error("Run:  wasm-pack build --target web");
+  process.exit(1);
+}
+
+// ── 2. Bundle and serve ───────────────────────────────────────────────────────
+
+mkdirSync(resolve(ROOT, "dist"), { recursive: true });
+cpSync(resolve(ROOT, "web/index.html"),       resolve(ROOT, "dist/index.html"));
+cpSync(resolve(ROOT, "web/main.css"),         resolve(ROOT, "dist/main.css"));
+cpSync(resolve(ROOT, "pkg/truescad.js"),      resolve(ROOT, "dist/truescad.js"));
+cpSync(resolve(ROOT, "pkg/truescad_bg.wasm"), resolve(ROOT, "dist/truescad_bg.wasm"));
+writeFileSync(resolve(ROOT, "dist/.nojekyll"), "");
+
+const ctx = await esbuild.context({
+  entryPoints: [resolve(ROOT, "web/main.js")],
+  bundle: true,
+  outfile: resolve(ROOT, "dist/main.js"),
+  format: "esm",
+  external: ["./truescad.js"],
+});
+
+await ctx.rebuild();
+const { host } = await ctx.serve({ servedir: resolve(ROOT, "dist"), port: PORT });
+const url = `http://${host}:${PORT}`;
+console.log(`Server: ${url}`);
+
+// ── 3. Run Playwright test ────────────────────────────────────────────────────
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+const consoleMessages = [];
+page.on("console", msg => {
+  const type = msg.type();
+  const text = msg.text();
+  consoleMessages.push({ type, text });
+  if (type === "error") console.log(`  [console.error] ${text}`);
+  if (type === "warning") console.log(`  [console.warn]  ${text}`);
+});
+
+page.on("pageerror", err => {
+  console.error(`  [pageerror] ${err.message}`);
+  consoleMessages.push({ type: "pageerror", text: err.message });
+});
+
+let passed = true;
+
+try {
+  // Load page
+  console.log("\n── Load page ──");
+  await page.goto(url, { waitUntil: "networkidle" });
+  console.log("  OK");
+
+  // Wait for WASM init. main.js calls init() async; we detect completion by
+  // intercepting the first click-listener registration on btn-run via a short
+  // script injected before the page script runs.
+  await page.addInitScript(() => {
+    window.__wasmReady = false;
+    const orig = EventTarget.prototype.addEventListener;
+    EventTarget.prototype.addEventListener = function(type, fn, ...rest) {
+      if (type === 'click' && this?.id === 'btn-run') window.__wasmReady = true;
+      return orig.call(this, type, fn, ...rest);
+    };
+  });
+
+  // Reload so the init script runs before main.js
+  await page.reload({ waitUntil: "networkidle" });
+  await page.waitForFunction(() => window.__wasmReady === true, { timeout: 15000 });
+
+  // Click Run and wait for log to update
+  console.log("── Click Run ──");
+  await page.click("#btn-run");
+  await page.waitForFunction(
+    () => document.getElementById("log").textContent !== "Ready. Press Run to evaluate the script.",
+    { timeout: 15000 }
+  );
+
+  // Read log output
+  const logText = await page.$eval("#log", el => el.textContent);
+  const logClass = await page.$eval("#log", el => el.className);
+  console.log(`  log class : ${logClass || "(none)"}`);
+  console.log(`  log text  : ${logText}`);
+
+  if (logClass === "error") {
+    console.error("  FAIL: script returned an error");
+    passed = false;
+  } else {
+    console.log("  OK: script ran without error");
+  }
+
+  // Check for JS errors in console
+  const jsErrors = consoleMessages.filter(m => m.type === "error" || m.type === "pageerror");
+  if (jsErrors.length > 0) {
+    console.error(`  FAIL: ${jsErrors.length} console error(s)`);
+    passed = false;
+  }
+
+  if (SCREENSHOT) {
+    const shot = resolve(ROOT, "dist/screenshot.png");
+    await page.screenshot({ path: shot });
+    console.log(`\nScreenshot saved: ${shot}`);
+  }
+
+} finally {
+  await browser.close();
+  await ctx.dispose();
+}
+
+console.log(`\n${passed ? "PASS" : "FAIL"}`);
+process.exit(passed ? 0 : 1);


### PR DESCRIPTION
- Add tests/browser.mjs: headless Chromium smoke test that starts an esbuild server, loads the app, clicks Run, and checks for errors; add test:browser / test:browser:screenshot npm scripts
- Bump tessellation 0.9 → 0.11 (ImplicitFunction no longer requires bbox(); tessellate() auto-detects bounds via find_bounds())
- Remove bbox() from ObjectAdaptor to match the new trait